### PR TITLE
Change setDomainCookies to no

### DIFF
--- a/src/Application.cfc
+++ b/src/Application.cfc
@@ -2,6 +2,7 @@
 	<cfscript>
 		this.name = "mango_#right(hash(GetDirectoryFromPath(GetCurrentTemplatePath())),50)#_v1_7";
 		this.setclientcookies="yes";
+		this.setDomainCookies="no";
 		this.sessionmanagement="yes";
 		this.sessiontimeout= CreateTimeSpan(0,0,60,0);
 


### PR DESCRIPTION
It appears that the default value for setDomainCookies is not amenable when using multiple subdomains (when you _do not_ want to share the cookies).

For example, I have **blog.alumniq.com** and **{random-client}.alumniq.com**, and there is no need to share the Mango session between them. In fact, having the mango session cookies at all prevents me from being able to log into the other sites, because I then end up with multiple `cfid` and `cftoken` cookies.

Setting `this.setDomainCookies="no";` in my Mango installs has resolved this cookie conflict with my other subdomains.
